### PR TITLE
修复工程在react-native run-android下报react-native-speech-iflytek中的AndroidManifest.xml报错，兼容0.47上下版本

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Example/node_modules/
 .DS_Store
+.idea

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ react-native link
 2. 替换 SDK 文件：
     1. 使用下载 Android SDK 的 `Android_voice_xxxx_xxxxxxxx/libs` 文件夹替换 `Example/node_modules/react-native-speech-iflytek/android/libs` 文件夹；
     2. 使用下载 iOS SDK 的 `iOS_voice_xxxx_xxxxxxxx/libs` 文件夹替换 `Example/node_modules/react-native-speech-iflytek/ios/libs` 文件夹。
+    
 3. iOS 平台还需手动添加部分依赖库：
     1. 在 XCode 中打开 `Example/ios/YourProject.xcodeproj`；
     2. 将讯飞框架文件 `Example/node_modules/react-native-speech-iflytek/ios/libs/iflyMSC.framework` 拖入 Project navigator 的 `Frameworks` 下，注意选择 `Copy items if needed`；
@@ -32,7 +33,23 @@ react-native link
         - UIKit.framework
         - Foundation.framework
         - CoreGraphics.framework
-
+        
+4.android平台权限
+   ```
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <!--读取网络信息状态 -->
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <!--获取当前wifi状态 -->
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
+    <!--允许程序改变网络连接状态 -->
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE"/>
+    <!--读取手机信息权限 -->
+    <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
+    <uses-permission android:name="android.permission.WRITE_SETTINGS" />
+   ```
 ## Usage
 （详见 Example）引入包：
 ```

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,24 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
 
     package="com.zphhhhh.speech">
-
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.RECORD_AUDIO" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <!--读取网络信息状态 -->
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-    <!--获取当前wifi状态 -->
-    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
-    <!--允许程序改变网络连接状态 -->
-    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE"/>
-    <!--读取手机信息权限 -->
-    <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
-    <uses-permission android:name="android.permission.WRITE_SETTINGS" />
-
-    <application android:allowBackup="true" android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
-
 </manifest>

--- a/android/src/main/java/com/zphhhhh/speech/SpeechPackage.java
+++ b/android/src/main/java/com/zphhhhh/speech/SpeechPackage.java
@@ -26,7 +26,10 @@ public class SpeechPackage implements ReactPackage {
 
         return modules;
     }
-
+    //@Override >0.47已经过期
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return Collections.emptyList();
+    }
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();


### PR DESCRIPTION
做了一下两步：
1，将react-native-speech-iflytek的AndroidManifest.xml中的不必要的东西删除，将android所需权限写入README.md中。
2，在SpeechPackage.java加入 createJSModules函数，只是将ovverride注解去掉，这样就可以兼容0.47上下的版本了。